### PR TITLE
Revamp add place experience and fix polygon tap

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   latlong2: ^0.9.1
   geolocator: ^12.0.0
   shared_preferences: ^2.3.2
+  image_picker: ^1.1.1
 
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1


### PR DESCRIPTION
## Summary
- switch the add place flow to English copy and reuse a Google Maps style pin for custom markers
- add a searchable category picker, optional photo upload, and improved details sheet for saved places
- resolve polygon tap errors by handling selection through map taps instead of unsupported polygon callbacks

## Testing
- No automated tests were run (Flutter SDK is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d8dd4456f4832486125a8b9b4b5183