### PR TITLE
feat: add address autocomplete to add place form

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,7 +209,7 @@ packages:
     source: hosted
     version: "0.2.5"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   shared_preferences: ^2.3.2
   image_picker: ^1.1.1
   provider: ^6.1.2
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_launcher_icons: ^0.13.1


### PR DESCRIPTION
## Summary
- add Nominatim-powered address suggestions to the Add Place form and sync the map marker when a suggestion is chosen
- show inline loading/error feedback for address lookups and restyle all form fields with filled, rounded inputs to match the reference UI
- add the `http` dependency required for the geocoding requests

## Testing
- not run (Flutter tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d8f57037c8832486f1b642728abc34