### PR TITLE
Adjust custom place marker visuals

### DIFF
--- a/lib/features/geofence/presentation/widgets/custom_place_marker.dart
+++ b/lib/features/geofence/presentation/widgets/custom_place_marker.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:balumohol/features/geofence/models/custom_place.dart';
-import 'package:balumohol/features/geofence/presentation/widgets/google_style_marker.dart';
 import 'package:balumohol/features/geofence/utils/place_category_styles.dart';
 
 class CustomPlaceMarker extends StatelessWidget {
@@ -67,7 +66,6 @@ class CustomPlaceMarker extends StatelessWidget {
                   ],
                 ),
               ),
-            GoogleStyleMarker(color: style.color),
           ],
         ),
       ),

--- a/lib/features/geofence/presentation/widgets/place_details_sheet.dart
+++ b/lib/features/geofence/presentation/widgets/place_details_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:balumohol/features/geofence/models/custom_place.dart';
+import 'package:balumohol/features/geofence/utils/place_category_styles.dart';
 
 class PlaceDetailsSheet extends StatelessWidget {
   const PlaceDetailsSheet({
@@ -15,6 +16,8 @@ class PlaceDetailsSheet extends StatelessWidget {
     final theme = Theme.of(context);
     final entries = place.details();
     final imageBytes = place.imageBytes;
+    final style = styleForCategory(place.category);
+    final placeName = place.name.isEmpty ? 'New place' : place.name;
 
     return DraggableScrollableSheet(
       expand: false,
@@ -36,11 +39,26 @@ class PlaceDetailsSheet extends StatelessWidget {
                 Row(
                   children: [
                     Expanded(
-                      child: Text(
-                        place.name.isEmpty ? 'New place' : place.name,
-                        style: theme.textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.location_on,
+                            color: style.color,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              placeName,
+                              style: theme.textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: style.color,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                     IconButton(


### PR DESCRIPTION
## Summary
- remove the Google-style pin from custom place markers so the badge stands alone on the map
- highlight the selected place name in the details sheet with a location icon that matches the marker style

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d90cbd8b848324bf593e01b38ddbe6