### PR TITLE
Improve custom place marker alignment and styling

### DIFF
--- a/lib/features/geofence/presentation/pages/geofence_map_page.dart
+++ b/lib/features/geofence/presentation/pages/geofence_map_page.dart
@@ -236,8 +236,8 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
           (place) => Marker(
             point: place.location,
             width: 160,
-            height: 140,
-            alignment: Alignment.topCenter,
+            height: 120,
+            alignment: Alignment.bottomCenter,
             child: CustomPlaceMarker(
               place: place,
               onTap: () => _showCustomPlaceDetails(place),

--- a/lib/features/geofence/presentation/widgets/custom_place_marker.dart
+++ b/lib/features/geofence/presentation/widgets/custom_place_marker.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:balumohol/features/geofence/models/custom_place.dart';
+import 'package:balumohol/features/geofence/presentation/widgets/google_style_marker.dart';
 import 'package:balumohol/features/geofence/utils/place_category_styles.dart';
 
 class CustomPlaceMarker extends StatelessWidget {
@@ -25,11 +26,10 @@ class CustomPlaceMarker extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (markerLabel.isNotEmpty)
+            if (markerLabel.isNotEmpty) ...[
               Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                margin: const EdgeInsets.only(bottom: 6),
                 decoration: BoxDecoration(
                   color: style.color,
                   borderRadius: BorderRadius.circular(20),
@@ -66,6 +66,9 @@ class CustomPlaceMarker extends StatelessWidget {
                   ],
                 ),
               ),
+              const SizedBox(height: 6),
+            ],
+            GoogleStyleMarker(color: style.color),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- show the custom place name/category alongside a pin-style icon on map markers
- anchor custom place markers to the bottom center so the icon stays on the saved location when zooming

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d90f2fa1dc8324b674906ff8998b32