### PR TITLE
Adjust custom place markers to remove icon and scale with zoom

### DIFF
--- a/lib/features/geofence/presentation/pages/geofence_map_page.dart
+++ b/lib/features/geofence/presentation/pages/geofence_map_page.dart
@@ -25,6 +25,8 @@ class GeofenceMapPage extends StatefulWidget {
 
 class _GeofenceMapPageState extends State<GeofenceMapPage> {
   static const double _customPlaceMarkerZoomThreshold = 14;
+  static const double _customPlaceMarkerBaseWidth = 160;
+  static const double _customPlaceMarkerBaseHeight = 64;
 
   bool _initialised = false;
   double _currentZoom = 15;
@@ -231,20 +233,42 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
       return const [];
     }
 
+    final scale = _markerScaleForZoom(_currentZoom);
+    final markerWidth = _customPlaceMarkerBaseWidth * scale;
+    final markerHeight = _customPlaceMarkerBaseHeight * scale;
+
     return controller.customPlaces
         .map(
           (place) => Marker(
             point: place.location,
-            width: 160,
-            height: 120,
+            width: markerWidth,
+            height: markerHeight,
             alignment: Alignment.bottomCenter,
             child: CustomPlaceMarker(
               place: place,
               onTap: () => _showCustomPlaceDetails(place),
+              scale: scale,
             ),
           ),
         )
         .toList();
+  }
+
+  double _markerScaleForZoom(double zoom) {
+    const double minZoom = _customPlaceMarkerZoomThreshold;
+    const double maxZoom = 18;
+    const double minScale = 0.6;
+    const double maxScale = 1.0;
+
+    if (zoom <= minZoom) {
+      return minScale;
+    }
+    if (zoom >= maxZoom) {
+      return maxScale;
+    }
+
+    final interpolationFactor = (zoom - minZoom) / (maxZoom - minZoom);
+    return minScale + (maxScale - minScale) * interpolationFactor;
   }
 
   Future<void> _goToCurrentLocation(GeofenceMapController controller) async {

--- a/lib/features/geofence/presentation/widgets/custom_place_marker.dart
+++ b/lib/features/geofence/presentation/widgets/custom_place_marker.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:balumohol/features/geofence/models/custom_place.dart';
-import 'package:balumohol/features/geofence/presentation/widgets/google_style_marker.dart';
 import 'package:balumohol/features/geofence/utils/place_category_styles.dart';
 
 class CustomPlaceMarker extends StatelessWidget {
@@ -9,10 +8,12 @@ class CustomPlaceMarker extends StatelessWidget {
     super.key,
     required this.place,
     required this.onTap,
+    this.scale = 1.0,
   });
 
   final CustomPlace place;
   final VoidCallback onTap;
+  final double scale;
 
   @override
   Widget build(BuildContext context) {
@@ -23,53 +24,59 @@ class CustomPlaceMarker extends StatelessWidget {
       child: Tooltip(
         message:
             '${place.name.isEmpty ? 'Unnamed place' : place.name}\nCategory: ${place.category}\nAddress: ${place.address}',
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (markerLabel.isNotEmpty) ...[
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                decoration: BoxDecoration(
-                  color: style.color,
-                  borderRadius: BorderRadius.circular(20),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.25),
-                      blurRadius: 6,
-                      offset: const Offset(0, 2),
-                    ),
-                  ],
-                ),
-                constraints: const BoxConstraints(maxWidth: 160),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      style.icon,
-                      size: 16,
-                      color: Colors.white,
-                    ),
-                    const SizedBox(width: 6),
-                    Flexible(
-                      child: Text(
-                        markerLabel,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+        child: Transform.scale(
+          scale: scale,
+          alignment: Alignment.bottomCenter,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (markerLabel.isNotEmpty)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: style.color,
+                    borderRadius: BorderRadius.circular(20),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.25),
+                        blurRadius: 6,
+                        offset: const Offset(0, 2),
                       ),
+                    ],
+                  ),
+                  constraints: const BoxConstraints(maxWidth: 160),
+                  child: Center(
+                    child: Text(
+                      markerLabel,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
                     ),
-                  ],
+                  ),
+                )
+              else
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: style.color,
+                    shape: BoxShape.circle,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.25),
+                        blurRadius: 4,
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(height: 6),
             ],
-            GoogleStyleMarker(color: style.color),
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- remove the extra location glyph from custom place marker labels to declutter the map
- scale custom place markers relative to the current zoom so they shrink when zoomed out

## Testing
- not run (Flutter SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9146df8f48324ac6210faba63540f