### PR TITLE
Update custom place marker styling

### DIFF
--- a/lib/features/geofence/presentation/widgets/custom_place_marker.dart
+++ b/lib/features/geofence/presentation/widgets/custom_place_marker.dart
@@ -19,6 +19,7 @@ class CustomPlaceMarker extends StatelessWidget {
   Widget build(BuildContext context) {
     final style = styleForCategory(place.category);
     final markerLabel = place.name.isNotEmpty ? place.name : place.category;
+    const markerColor = Color(0xFF1976D2);
     return GestureDetector(
       onTap: onTap,
       child: Tooltip(
@@ -34,46 +35,37 @@ class CustomPlaceMarker extends StatelessWidget {
                 Container(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: style.color,
-                    borderRadius: BorderRadius.circular(20),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.25),
-                        blurRadius: 6,
-                        offset: const Offset(0, 2),
+                  constraints: const BoxConstraints(maxWidth: 160),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        style.icon,
+                        size: 18,
+                        color: markerColor,
+                      ),
+                      const SizedBox(width: 6),
+                      Flexible(
+                        child: Text(
+                          markerLabel,
+                          style: TextStyle(
+                            color: markerColor,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                        ),
                       ),
                     ],
-                  ),
-                  constraints: const BoxConstraints(maxWidth: 160),
-                  child: Center(
-                    child: Text(
-                      markerLabel,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                    ),
                   ),
                 )
               else
-                Container(
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    color: style.color,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.25),
-                        blurRadius: 4,
-                      ),
-                    ],
-                  ),
+                Icon(
+                  style.icon,
+                  color: markerColor,
+                  size: 20,
                 ),
             ],
           ),


### PR DESCRIPTION
## Summary
- show the place category icon alongside the custom place name
- remove the tinted background from the marker label and restyle the icon/text in a consistent blue

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d918f0cd1483248db8d2508e8b1174