### PR TITLE
Highlight selected custom place marker

### DIFF
--- a/lib/features/geofence/presentation/pages/geofence_map_page.dart
+++ b/lib/features/geofence/presentation/pages/geofence_map_page.dart
@@ -30,6 +30,7 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
 
   bool _initialised = false;
   double _currentZoom = 15;
+  CustomPlace? _selectedCustomPlace;
 
   bool get _showCustomPlaceMarkers =>
       _currentZoom >= _customPlaceMarkerZoomThreshold;
@@ -248,6 +249,7 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
               place: place,
               onTap: () => _showCustomPlaceDetails(place),
               scale: scale,
+              isSelected: identical(place, _selectedCustomPlace),
             ),
           ),
         )
@@ -309,12 +311,21 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
   }
 
   Future<void> _showCustomPlaceDetails(CustomPlace place) async {
+    setState(() {
+      _selectedCustomPlace = place;
+    });
+
     await showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
       isScrollControlled: true,
       builder: (context) => PlaceDetailsSheet(place: place),
     );
+
+    if (!mounted) return;
+    setState(() {
+      _selectedCustomPlace = null;
+    });
   }
 
   Future<void> _showPolygonDetails(

--- a/lib/features/geofence/presentation/widgets/custom_place_marker.dart
+++ b/lib/features/geofence/presentation/widgets/custom_place_marker.dart
@@ -9,17 +9,20 @@ class CustomPlaceMarker extends StatelessWidget {
     required this.place,
     required this.onTap,
     this.scale = 1.0,
+    this.isSelected = false,
   });
 
   final CustomPlace place;
   final VoidCallback onTap;
   final double scale;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
     final style = styleForCategory(place.category);
     final markerLabel = place.name.isNotEmpty ? place.name : place.category;
     const markerColor = Color(0xFF1976D2);
+    const selectedColor = Color(0xFFE53935);
     return GestureDetector(
       onTap: onTap,
       child: Tooltip(
@@ -31,7 +34,41 @@ class CustomPlaceMarker extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (markerLabel.isNotEmpty)
+              if (isSelected) ...[
+                const Icon(
+                  Icons.location_on,
+                  color: selectedColor,
+                  size: 48,
+                ),
+                if (markerLabel.isNotEmpty)
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    constraints: const BoxConstraints(maxWidth: 160),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: const [
+                        BoxShadow(
+                          color: Colors.black26,
+                          blurRadius: 4,
+                          offset: Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Text(
+                      markerLabel,
+                      style: const TextStyle(
+                        color: selectedColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+              ] else if (markerLabel.isNotEmpty)
                 Container(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 10, vertical: 6),


### PR DESCRIPTION
## Summary
- track the currently selected custom place so it can be highlighted on the map
- swap the custom place marker visuals to a red location pin while its details sheet is open
- restore the original marker appearance when the bottom sheet closes

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d91f7de9308324a8ba8026218fd9ef