### PR TITLE
Add manual tracking toggle with path visualization

### DIFF
--- a/lib/features/geofence/presentation/widgets/current_location_indicator.dart
+++ b/lib/features/geofence/presentation/widgets/current_location_indicator.dart
@@ -1,7 +1,12 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 class CurrentLocationIndicator extends StatelessWidget {
-  const CurrentLocationIndicator({super.key});
+  const CurrentLocationIndicator({super.key, this.heading});
+
+  /// Heading in degrees (0° = north, increasing clockwise).
+  final double? heading;
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +46,22 @@ class CurrentLocationIndicator extends StatelessWidget {
             color: Colors.white,
           ),
         ),
+        if (heading != null)
+          Transform.rotate(
+            angle: heading! * math.pi / 180,
+            child: const Icon(
+              Icons.navigation,
+              size: 26,
+              color: Colors.white,
+              shadows: [
+                Shadow(
+                  color: Color(0x33000000),
+                  blurRadius: 6,
+                  offset: Offset(0, 2),
+                ),
+              ],
+            ),
+          ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- add a start/stop tracking button that records markers on demand and renders the walked path as a polyline
- update the geofence map controller to manage tracking state, persist the path, and compute heading from GPS samples
- show the current heading with an arrow-styled current location indicator for better orientation cues

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da57e9ed4083249a1ca56a6c0aea93