### PR TITLE
Fix sidebar AnimatedContainer decoration assertion

### DIFF
--- a/lib/features/geofence/presentation/pages/geofence_map_page.dart
+++ b/lib/features/geofence/presentation/pages/geofence_map_page.dart
@@ -169,6 +169,9 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
             curve: Curves.easeInOut,
             width: _isSidebarCollapsed ? 0 : 320,
             clipBehavior: Clip.hardEdge,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+            ),
             child: IgnorePointer(
               ignoring: _isSidebarCollapsed,
               child: _MapSidebar(


### PR DESCRIPTION
## Summary
- add a surface-colored decoration to the geofence map sidebar's AnimatedContainer so it can safely clip its child

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68da73e586108324b45fd29b495baf1c