### PR TITLE
Simplify geofence sidebar and update mouza defaults

### DIFF
--- a/lib/features/geofence/presentation/pages/geofence_map_page.dart
+++ b/lib/features/geofence/presentation/pages/geofence_map_page.dart
@@ -164,16 +164,9 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
       ),
       body: Row(
         children: [
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 250),
-            curve: Curves.easeInOut,
-            width: _isSidebarCollapsed ? 0 : 320,
-            clipBehavior: Clip.hardEdge,
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surface,
-            ),
-            child: IgnorePointer(
-              ignoring: _isSidebarCollapsed,
+          if (!_isSidebarCollapsed) ...[
+            SizedBox(
+              width: 320,
               child: _MapSidebar(
                 controller: controller,
                 isTracking: isTracking,
@@ -189,9 +182,8 @@ class _GeofenceMapPageState extends State<GeofenceMapPage> {
                 onToggleOtherPolygons: controller.setShowOtherPolygons,
               ),
             ),
-          ),
-          if (!_isSidebarCollapsed)
             const VerticalDivider(width: 1, thickness: 1),
+          ],
           Expanded(
             child: Stack(
               children: [

--- a/lib/features/geofence/providers/geofence_map_controller.dart
+++ b/lib/features/geofence/providers/geofence_map_controller.dart
@@ -387,8 +387,7 @@ class GeofenceMapController extends ChangeNotifier {
               .where((name) => name.isNotEmpty),
         );
       _selectedMouzaNames
-        ..clear()
-        ..addAll(_availableMouzaNames);
+        ..removeWhere((name) => !_availableMouzaNames.contains(name));
 
       _geofencePolygons
         ..clear()


### PR DESCRIPTION
## Summary
- replace the animated geofence sidebar with a static layout to avoid expensive rebuilds on large datasets
- keep previously chosen mouzas but avoid auto-selecting every mouza when data loads to prevent lag on first load

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da760a94b883249ce51ea1fc18f6ef