### PR TITLE
Add user polygon drawing tools and polygon labels

### DIFF
--- a/lib/features/geofence/constants.dart
+++ b/lib/features/geofence/constants.dart
@@ -7,6 +7,7 @@ const String historyStorageKey = 'locationHistory';
 const Duration sampleRetentionDuration = Duration(seconds: 12);
 const double defaultFollowZoom = 17;
 const String customPlacesStorageKey = 'customPlaces';
+const String userPolygonsStorageKey = 'userPolygons';
 
 const List<String> placeCategories = [
   'Restaurant',

--- a/lib/features/geofence/models/user_polygon.dart
+++ b/lib/features/geofence/models/user_polygon.dart
@@ -1,0 +1,59 @@
+import 'dart:ui';
+
+import 'package:latlong2/latlong.dart';
+
+class UserPolygon {
+  const UserPolygon({
+    required this.id,
+    required this.name,
+    required this.colorValue,
+    required this.points,
+  });
+
+  factory UserPolygon.fromJson(Map<String, dynamic> json) {
+    final rawPoints = json['points'] as List<dynamic>? ?? const [];
+    final points = rawPoints
+        .whereType<Map<String, dynamic>>()
+        .map(
+          (point) => LatLng(
+            (point['lat'] as num?)?.toDouble() ?? 0,
+            (point['lng'] as num?)?.toDouble() ?? 0,
+          ),
+        )
+        .toList();
+
+    return UserPolygon(
+      id: (json['id'] as String? ?? '').trim().isEmpty
+          ? DateTime.now().millisecondsSinceEpoch.toString()
+          : (json['id'] as String).trim(),
+      name: (json['name'] as String? ?? '').trim(),
+      colorValue: (json['color'] as num?)?.toInt() ?? _defaultColorValue,
+      points: points,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'color': colorValue,
+      'points': points
+          .map(
+            (point) => {
+              'lat': point.latitude,
+              'lng': point.longitude,
+            },
+          )
+          .toList(),
+    };
+  }
+
+  Color get color => Color(colorValue);
+
+  final String id;
+  final String name;
+  final int colorValue;
+  final List<LatLng> points;
+}
+
+const int _defaultColorValue = 0xFF1976D2;


### PR DESCRIPTION
## Summary
- allow drawing custom polygons with color/name selection, including an in-map creation workflow and persistence
- show polygon names directly on the map and reorganize the sidebar information buttons with a collapsible বালুমহাল সমূহ section
- add storage for user polygons via a dedicated model and controller wiring so custom areas persist across sessions

## Testing
- not run (flutter CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68db93af5b1083249dc3038e86eaf690