### PR TITLE
Fix polygon dialog controller disposal

### DIFF
--- a/lib/features/geofence/presentation/pages/draw_polygon_page.dart
+++ b/lib/features/geofence/presentation/pages/draw_polygon_page.dart
@@ -92,7 +92,7 @@ class _DrawPolygonPageState extends State<DrawPolygonPage> {
     final nameController = TextEditingController();
     Color selectedColor = _polygonColorOptions.first.color;
     try {
-      return showDialog<_PolygonDetails>(
+      return await showDialog<_PolygonDetails>(
         context: context,
         builder: (context) {
           return StatefulBuilder(


### PR DESCRIPTION
## Summary
- await the polygon details dialog before disposing its text controller to avoid using it after disposal

## Testing
- flutter test *(fails: Flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db9ea0a7348324bd8d75563aedd435