### PR TITLE
Add output layer styling, new map controls, and language toggle

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:balumohol/core/language/language_controller.dart';
 import 'package:balumohol/core/location/location_service.dart';
 import 'package:balumohol/core/storage/preferences_service.dart';
 import 'package:balumohol/features/geofence/presentation/pages/geofence_map_page.dart';
@@ -13,6 +14,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(
+          create: (_) => LanguageController(),
+        ),
         ChangeNotifierProvider(
           create: (_) => GeofenceMapController(
             locationService: const GeolocatorLocationService(),

--- a/lib/core/language/language_controller.dart
+++ b/lib/core/language/language_controller.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+
+enum AppLanguage { bangla, english }
+
+extension AppLanguageX on AppLanguage {
+  bool get isBangla => this == AppLanguage.bangla;
+
+  String get displayName => switch (this) {
+        AppLanguage.bangla => 'বাংলা',
+        AppLanguage.english => 'English',
+      };
+}
+
+class LanguageController extends ChangeNotifier {
+  AppLanguage _language = AppLanguage.bangla;
+
+  AppLanguage get language => _language;
+
+  void setLanguage(AppLanguage language) {
+    if (_language == language) return;
+    _language = language;
+    notifyListeners();
+  }
+}

--- a/lib/core/utils/formatting.dart
+++ b/lib/core/utils/formatting.dart
@@ -33,31 +33,71 @@ String _trimTrailingZeros(String value) {
   return result;
 }
 
-String formatNumber(num value, {int fractionDigits = 0}) {
+String formatNumber(
+  num value, {
+  int fractionDigits = 0,
+  bool useBanglaDigits = true,
+}) {
   String text;
   if (fractionDigits <= 0) {
     text = value.round().toString();
   } else {
     text = _trimTrailingZeros(value.toStringAsFixed(fractionDigits));
   }
-  return toBanglaDigits(text);
+  return useBanglaDigits ? toBanglaDigits(text) : text;
 }
 
-String formatMeters(num value, {int fractionDigits = 0}) {
-  return '${formatNumber(value, fractionDigits: fractionDigits)} মিটার';
+String formatMeters(
+  num value, {
+  int fractionDigits = 0,
+  bool useBanglaDigits = true,
+  String? unitLabel,
+}) {
+  final resolvedUnit = unitLabel ?? (useBanglaDigits ? 'মিটার' : 'meters');
+  return '${formatNumber(
+    value,
+    fractionDigits: fractionDigits,
+    useBanglaDigits: useBanglaDigits,
+  )} $resolvedUnit';
 }
 
-String formatKilometers(double value, {int fractionDigits = 2}) {
-  return '${formatNumber(value, fractionDigits: fractionDigits)} কিমি';
+String formatKilometers(
+  double value, {
+  int fractionDigits = 2,
+  bool useBanglaDigits = true,
+  String? unitLabel,
+}) {
+  final resolvedUnit = unitLabel ?? (useBanglaDigits ? 'কিমি' : 'km');
+  return '${formatNumber(
+    value,
+    fractionDigits: fractionDigits,
+    useBanglaDigits: useBanglaDigits,
+  )} $resolvedUnit';
 }
 
-String formatCoordinate(double value) {
-  return formatNumber(value, fractionDigits: 6);
+String formatCoordinate(double value, {bool useBanglaDigits = true}) {
+  return formatNumber(
+    value,
+    fractionDigits: 6,
+    useBanglaDigits: useBanglaDigits,
+  );
 }
 
-String formatLatLng(LatLng point, {int fractionDigits = 6}) {
-  final latText = formatNumber(point.latitude, fractionDigits: fractionDigits);
-  final lngText = formatNumber(point.longitude, fractionDigits: fractionDigits);
+String formatLatLng(
+  LatLng point, {
+  int fractionDigits = 6,
+  bool useBanglaDigits = true,
+}) {
+  final latText = formatNumber(
+    point.latitude,
+    fractionDigits: fractionDigits,
+    useBanglaDigits: useBanglaDigits,
+  );
+  final lngText = formatNumber(
+    point.longitude,
+    fractionDigits: fractionDigits,
+    useBanglaDigits: useBanglaDigits,
+  );
   return '$latText, $lngText';
 }
 
@@ -107,7 +147,11 @@ List<MapEntry<String, String>> polygonReadableProperties(
       .map(
         (entry) => MapEntry(
           prettifyPropertyKey(entry.key),
-          formatPropertyValue(entry.value),
+          formatPropertyValue(
+            entry.value,
+            useBanglaDigits: useBanglaDigits,
+            notAvailableLabel: notAvailableLabel,
+          ),
         ),
       )
       .toList();
@@ -140,22 +184,50 @@ String prettifyPropertyKey(String key) {
       .join(' ');
 }
 
-String formatPropertyValue(dynamic value) {
+String formatPropertyValue(
+  dynamic value, {
+  bool useBanglaDigits = true,
+  String? notAvailableLabel,
+}) {
+  final unavailable =
+      notAvailableLabel ?? (useBanglaDigits ? 'উপলব্ধ নয়' : 'Not available');
   if (value == null) {
-    return 'উপলব্ধ নয়';
+    return unavailable;
   }
   if (value is int) {
-    return formatNumber(value, fractionDigits: 0);
+    return formatNumber(
+      value,
+      fractionDigits: 0,
+      useBanglaDigits: useBanglaDigits,
+    );
   }
   if (value is double) {
     final fractionDigits = (value - value.roundToDouble()).abs() < 1e-6 ? 0 : 2;
-    return formatNumber(value, fractionDigits: fractionDigits);
+    return formatNumber(
+      value,
+      fractionDigits: fractionDigits,
+      useBanglaDigits: useBanglaDigits,
+    );
   }
   if (value is num) {
-    return formatNumber(value, fractionDigits: 2);
+    return formatNumber(
+      value,
+      fractionDigits: 2,
+      useBanglaDigits: useBanglaDigits,
+    );
   }
   if (value is String) {
-    return toBanglaDigits(value.trim());
+    final trimmed = value.trim();
+    return useBanglaDigits ? toBanglaDigits(trimmed) : trimmed;
   }
   return value.toString();
+}
+
+String formatTimestampLocalized(
+  int timestampMs, {
+  required bool useBanglaDigits,
+}) {
+  return useBanglaDigits
+      ? formatTimestampBangla(timestampMs)
+      : formatTimestampEnglish(timestampMs);
 }

--- a/lib/features/geofence/constants.dart
+++ b/lib/features/geofence/constants.dart
@@ -91,3 +91,5 @@ final polygonBaseBorderColor = Colors.blue.shade600;
 final polygonSelectedBorderColor = Colors.orange.shade700;
 final polygonBaseFillColor = const Color(0xFF42A5F5).withOpacity(0.2);
 final polygonSelectedFillColor = const Color(0xFFFFB74D).withOpacity(0.35);
+const Color outputPolygonFillColor = Color(0xFFFFE082);
+const Color outputPolygonBorderColor = Color(0xFFE65100);

--- a/lib/features/geofence/presentation/widgets/polygon_details_sheet.dart
+++ b/lib/features/geofence/presentation/widgets/polygon_details_sheet.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
+
+import 'package:balumohol/core/language/language_controller.dart';
 import 'package:balumohol/core/utils/formatting.dart';
 import 'package:balumohol/features/geofence/models/polygon_feature.dart';
 
@@ -13,13 +16,22 @@ class PolygonDetailsSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final language = context.watch<LanguageController>().language;
+    final useBanglaDigits = language.isBangla;
     final theme = Theme.of(context);
-    final entries = polygonReadableProperties(polygon);
+    final entries = polygonReadableProperties(
+      polygon,
+      useBanglaDigits: useBanglaDigits,
+      notAvailableLabel:
+          language.isBangla ? 'উপলব্ধ নয়' : 'Not available',
+    );
 
     final plotNumber = polygon.properties['plot_number'];
     final String title = plotNumber != null
-        ? 'প্লট ${formatPropertyValue(plotNumber)}'
-        : 'প্লটের বিবরণ';
+        ? (language.isBangla
+            ? 'প্লট ${formatPropertyValue(plotNumber)}'
+            : 'Plot ${formatPropertyValue(plotNumber, useBanglaDigits: false)}')
+        : (language.isBangla ? 'প্লটের বিবরণ' : 'Plot details');
 
     return DraggableScrollableSheet(
       expand: false,
@@ -49,7 +61,7 @@ class PolygonDetailsSheet extends StatelessWidget {
                       ),
                     ),
                     IconButton(
-                      tooltip: 'Close',
+                      tooltip: language.isBangla ? 'বন্ধ করুন' : 'Close',
                       onPressed: () => Navigator.of(context).pop(),
                       icon: const Icon(Icons.close),
                     ),

--- a/lib/features/geofence/providers/geofence_map_controller.dart
+++ b/lib/features/geofence/providers/geofence_map_controller.dart
@@ -365,8 +365,9 @@ class GeofenceMapController extends ChangeNotifier {
     if (bounds == null) {
       return;
     }
-    final targetZoom = _zoomForBounds(bounds);
-    moveMap(bounds.center, targetZoom);
+    final center = polygonCentroid(polygon) ?? bounds.center;
+    final targetZoom = (_zoomForBounds(bounds) - 0.8).clamp(5, 18).toDouble();
+    moveMap(center, targetZoom);
   }
 
   void focusMouza(String mouzaName) {


### PR DESCRIPTION
## Summary
- highlight output polygons with a dedicated color palette and ensure they render above other layers
- center the map on polygon selections with a gentler zoom and add a top-right panel with language toggle and layer selector
- support Bangla/English switching for key map controls, polygon details, and measurement formatting via a new language controller

## Testing
- not run (Flutter tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e23f4e9dbc832492ab73b4c3be165e