### PR TITLE
Fix overflow when adding polygon custom field

### DIFF
--- a/lib/features/geofence/presentation/pages/draw_polygon_page.dart
+++ b/lib/features/geofence/presentation/pages/draw_polygon_page.dart
@@ -295,54 +295,56 @@ class _DrawPolygonPageState extends State<DrawPolygonPage> {
                 title: Text(
                   _localizedText(language, 'ক্ষেত্র যোগ করুন', 'Add field'),
                 ),
-                content: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    TextField(
-                      controller: nameController,
-                      decoration: InputDecoration(
-                        labelText: _localizedText(
-                          language,
-                          'ক্ষেত্রের নাম',
-                          'Field name',
-                        ),
-                        hintText: _localizedText(
-                          language,
-                          'যেমন: মালিকের নাম',
-                          'e.g. Owner name',
-                        ),
-                        errorText: nameError,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    DropdownButtonFormField<UserPolygonFieldType>(
-                      value: selectedType,
-                      decoration: InputDecoration(
-                        labelText: _localizedText(
-                          language,
-                          'ডেটার ধরন',
-                          'Data type',
+                content: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TextField(
+                        controller: nameController,
+                        decoration: InputDecoration(
+                          labelText: _localizedText(
+                            language,
+                            'ক্ষেত্রের নাম',
+                            'Field name',
+                          ),
+                          hintText: _localizedText(
+                            language,
+                            'যেমন: মালিকের নাম',
+                            'e.g. Owner name',
+                          ),
+                          errorText: nameError,
                         ),
                       ),
-                      items: UserPolygonFieldType.values
-                          .map(
-                            (type) => DropdownMenuItem(
-                              value: type,
-                              child: Text(
-                                _fieldTypeLabel(type, language),
+                      const SizedBox(height: 16),
+                      DropdownButtonFormField<UserPolygonFieldType>(
+                        value: selectedType,
+                        decoration: InputDecoration(
+                          labelText: _localizedText(
+                            language,
+                            'ডেটার ধরন',
+                            'Data type',
+                          ),
+                        ),
+                        items: UserPolygonFieldType.values
+                            .map(
+                              (type) => DropdownMenuItem(
+                                value: type,
+                                child: Text(
+                                  _fieldTypeLabel(type, language),
+                                ),
                               ),
-                            ),
-                          )
-                          .toList(),
-                      onChanged: (value) {
-                        if (value == null) return;
-                        setState(() {
-                          selectedType = value;
-                        });
-                      },
-                    ),
-                  ],
+                            )
+                            .toList(),
+                        onChanged: (value) {
+                          if (value == null) return;
+                          setState(() {
+                            selectedType = value;
+                          });
+                        },
+                      ),
+                    ],
+                  ),
                 ),
                 actions: [
                   TextButton(


### PR DESCRIPTION
## Summary
- wrap the polygon field creation dialog in a scrollable container so the keyboard no longer causes an overflow when adding extra information

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e259db5a088324803b650b80ad0322